### PR TITLE
fix: correct typo in the validate template for length restrictions

### DIFF
--- a/internal/templates/rtp20022/validate.tgo
+++ b/internal/templates/rtp20022/validate.tgo
@@ -137,7 +137,7 @@ import (
                                 }
 			{{- end }}
 			{{- if .Restriction.Length }}
-				if err := rtp.ValidateLength(string(v), {{ .Restriction.MinLength.Value }}); err != nil {
+				if err := rtp.ValidateLength(string(v), {{ .Restriction.Length.Value }}); err != nil {
                                 	return err
                                 }
 			{{- end }}


### PR DESCRIPTION
Fixes a typo that causes code generation to fail when a length restriction is present in a schema file. Note that this bug was found when attempting to use the project to generate code for a different specification where a length restriction is specified like so:
```
<xs:restriction base="xs:string">
      <xs:length value="65"/>
```
To reproduce this, one may paste the lines above into an existing schema file and then attempt to do
```
make generate
```
which ultimately fails with this error:
```
Could not execute template: template: internal/templates/rtp20022/validate.tgo:140:59: executing "internal/templates/rtp20022/validate.tgo" at <.Restriction.MinLength.Value>: nil pointer evaluating *xsd.MinLength.Value
```