### PR TITLE
Fix: Ensure Unique AdmnMessageID() Generation

### DIFF
--- a/pkg/rtp/serials.go
+++ b/pkg/rtp/serials.go
@@ -1,24 +1,23 @@
 package rtp
 
 import (
-	"encoding/base32"
+	"crypto/rand"
 	"fmt"
+	"math/big"
 	"time"
 )
 
+// AlphaSerialNumber generates a random alphanumeric serial number of the specified length
+// without depending on the current time.
 func AlphaSerialNumber(length int) string {
-	bs := []byte(fmt.Sprint(time.Now().UnixMilli()))
-	ss := base32.StdEncoding.EncodeToString(bs)
-	var serialNumber string
-	for i := len(ss) - 1; i >= 0; i-- {
-		if (ss[i] >= '0' && ss[i] <= '9') || (ss[i] >= 'A' && ss[i] <= 'Z') {
-			serialNumber += string(ss[i])
-		}
+	const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	serialNumber := make([]byte, length)
+
+	for i := range serialNumber {
+		randIndex, _ := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		serialNumber[i] = charset[randIndex.Int64()]
 	}
-	if len(serialNumber) > length {
-		serialNumber = serialNumber[:length]
-	}
-	return serialNumber
+	return string(serialNumber)
 }
 
 func NumericSerialNumber(length int) string {


### PR DESCRIPTION
Updated the AlphaSerialNumber function to guarantee unique message ID generation even when multiple IDs are created simultaneously. By eliminating the dependency on the current time, this fix ensures that message IDs remain distinct regardless of generation timing. This adjustment mitigates potential conflicts in message identification. This function is called inside AdmnMessageID(). (The issue will occur when you have two sets of queues and you are trying to echo at the same time in both queues. Generated message IDs will be exactly the same if they depend on time.)