### PR TITLE
fix(ci): make tag release job idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags: [ "v*.*.*" ]
 
+permissions:
+  contents: write
+
 jobs:
   testing:
     name: Testing
@@ -34,12 +37,20 @@ jobs:
     needs: [testing]
     runs-on: ubuntu-latest
     steps:
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
+    # actions/create-release@v1 fails when the release already exists (e.g. created by
+    # `gh release create` before the tag workflow runs) and used github.ref
+    # ("refs/tags/vX.Y.Z") as the tag name. Ensure the release exists idempotently.
+    - name: Ensure GitHub Release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        prerelease: true
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        TAG="${{ github.ref_name }}"
+        if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+          echo "Release $TAG already exists — nothing to do"
+        else
+          gh release create "$TAG" \
+            --repo "${{ github.repository }}" \
+            --title "$TAG" \
+            --generate-notes
+        fi


### PR DESCRIPTION
## Summary
- Release CI failed with `already_exists` when the release was pre-created for the tag.
- `actions/create-release@v1` used `github.ref` as the tag name.
- Ensure release exists via `gh` and use `github.ref_name`.

## Test plan
- [ ] Merge and re-point `v0.12.1` at this commit to re-run the release workflow